### PR TITLE
handle tags syncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ env:
   # Optional toggle to spawn time logs (keeps action active) 
   SPAWN_LOGS: "false" # "true" or "false"
   IGNORE_FILES: "dummy.ext"
+  # Optional tags refspec to push (leave empty to skip)
+  PUSH_TAGS: "refs/tags/v*"
 
 # This runs every day on 1801 UTC
 on:
@@ -62,6 +64,7 @@ jobs:
           push_args: ${{ env.PUSH_ARGS }}
           spawn_logs: ${{ env.SPAWN_LOGS }}
           ignore_files: ${{ env.IGNORE_FILES }}
+          push_tags: ${{ env.PUSH_TAGS }}
 ```
 
 This action syncs your repo (merge changes from `remote`) at branch `main` with the upstream repo ``` https://github.com/dabreadman/go-web-proxy.git ``` every day on 1801 UTC.  

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,11 @@ inputs:
     description: Git push arguments
     required: false
     default: ""
-  spawn_logs: 
+  push_tags:
+    description: Push tags from upstream repos downstream (use refspec, such as "refs/tags/*")
+    required: false
+    default: ""
+  spawn_logs:
     description: Toggle to spawn `sync-upstream-repo` with time logs
     required: true
     default: false
@@ -56,6 +60,7 @@ runs:
     - ${{ inputs.spawn_logs }}
     - ${{ inputs.downstream_repo }}
     - ${{ inputs.ignore_files }}
+    - ${{ inputs.push_tags }}
 
 branding:
   icon: "git-merge"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,8 @@ PUSH_ARGS=$7
 SPAWN_LOGS=$8
 DOWNSTREAM_REPO=$9
 IGNORE_FILES=${10}
+PUSH_TAGS=${11}
+
 
 if [[ -z "$UPSTREAM_REPO" ]]; then
   echo "Missing \$UPSTREAM_REPO"
@@ -87,6 +89,9 @@ elif [[ $MERGE_RESULT != *"Already up to date."* ]]
 then
   git commit -m "Merged upstream"
   git push ${PUSH_ARGS} origin ${DOWNSTREAM_BRANCH} || exit $?
+  if [[ -n ${PUSH_TAGS} ]]; then
+      git push origin ${PUSH_ARGS} ${PUSH_TAGS:-"refs/tags/*"}
+  fi
 fi
 
 cd ..

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,7 @@ fi
 if [[ -z "$DOWNSTREAM_BRANCH" ]]; then
   echo "Missing \$DOWNSTREAM_BRANCH"
   echo "Default to ${UPSTREAM_BRANCH}"
-  DOWNSTREAM_BREANCH=UPSTREAM_BRANCH
+  DOWNSTREAM_BRANCH=UPSTREAM_BRANCH
 fi
 
 if ! echo "$UPSTREAM_REPO" | grep '\.git'; then


### PR DESCRIPTION
It would be pretty useful to be able to sync tags from upstream repos to downstream repos. This PR implements just that.

Example usage:


```yaml
jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - name: GitHub Sync to Upstream Repository
        uses: dchourasia/sync-upstream-repo@main
        with:
          upstream_repo: ${{ env.UPSTREAM_URL }}
          upstream_branch: ${{ env.UPSTREAM_BRANCH }}
          downstream_repo: ${{ env.DOWNSTREAM_URL }}
          downstream_branch: ${{ env.DOWNSTREAM_BRANCH }}
          push_tags: "refs/tags/v*" # will push all tags matching "v*"
```

leaving `push_tags` empty keeps the current behaviour of not pushing tags.