### PR TITLE
Print upstream and downstream commit SHAs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,6 +83,12 @@ do
     cat .git/info/attributes
 done
 
+UPSTREAM_SHA=$(git rev-parse upstream/${UPSTREAM_BRANCH})
+DOWNSTREAM_SHA=$(git rev-parse HEAD)
+
+echo "Upstream commit:   $UPSTREAM_SHA"
+echo "Downstream commit: $DOWNSTREAM_SHA"
+
 MERGE_RESULT=$(git merge ${MERGE_ARGS} upstream/${UPSTREAM_BRANCH} 2>&1)
 echo $MERGE_RESULT
 


### PR DESCRIPTION
When a merge conflict fails a job, it is helpful to know exactly which commit SHAs were used in the merge to be able to reproduce the merge conflict locally.